### PR TITLE
Rebuild v 1.29:

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,7 +1,7 @@
 upload_channels:
-  - sfe1ed40
+  - ak_test
 channels:
-  - sfe1ed40
+  - ak_test
 #channel_targets:
 #  - sfe1ed40
 #build_parameters:

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,7 +1,7 @@
-upload_channels:
-  - ak_test
-channels:
-  - ak_test
+#upload_channels:
+#  - sfe1ed40
+#channels:
+#  - sfe1ed40
 #channel_targets:
 #  - sfe1ed40
 #build_parameters:

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -1,38 +1,10 @@
 #!/bin/bash
 echo "Building ${PKG_NAME}."
 
-# Isolate the build.
-mkdir -p build
-cd build || exit 1
-
-export CXXFLAGS="${CXXFLAGS} -O2 -g0 -fno-fast-math -Wall -Wno-unknown-pragmas -Werror"
-
-# TODO: Enable DQL_BUILD_TEST_SUITE with the next release. See comments below.
-cmake .. ${CMAKE_ARGS} \
-    -GNinja \
-    -DCMAKE_BUILD_TYPE=Release \
-    -DCMAKE_INSTALL_PREFIX=$PREFIX \
-    -DCMAKE_INSTALL_LIBDIR=lib     \
-    -DCMAKE_CXX_FLAGS="$CMAKE_CXX_FLAGS" \
-    -DQL_BUILD_EXAMPLES=OFF   \
-    -DQL_BUILD_TEST_SUITE=OFF \
-    -DQL_BUILD_BENCHMARK=OFF
-
-# Build.
-echo "Building..."
-ninja -j${CPU_COUNT} || exit 1
-
-# 2023/3/14: Disable testing below because 'quantlib_test_suite' fails 
-# in the test module "Master Test Suite" (failed to verify exponentially weightedmodified Bessel function of second kind) 
-# on linux-s390x and linux-aarch64.
-
-# ninja test || exit 1
-# ./test-suite/quantlib-test-suite --log_level=message || exit 1
-# ctest -VV --output-on-failure || exit 1
-
-# Installing
-echo "Installing..."
-ninja install || exit 1
+./autogen.sh
+./configure --disable-static CXXFLAGS="-O2 -g0 -Wall -Wno-unknown-pragmas -Werror" --prefix $PREFIX
+make
+make install
 
 # Error free exit!
 echo "Error free exit!"

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -13,7 +13,7 @@ source:
   sha256: {{ sha256 }}
 
 build:
-  number: 0
+  number: 1
   skip: true  # [win and vc<14]
   run_exports:
     - {{ pin_subpackage('quantlib', max_pin='x') }}  # [not win]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -34,6 +34,7 @@ requirements:
 test:
   commands:
     - quantlib-test-suite --log_level=message  # [win]
+    - quantlib-config --version
 
 about:
   home: https://www.quantlib.org/

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -34,7 +34,8 @@ requirements:
 test:
   commands:
     - quantlib-test-suite --log_level=message  # [win]
-    - quantlib-config --version
+    # quantlib-config is built only for unix-like systems
+    - quantlib-config --version  # [not win]
 
 about:
   home: https://www.quantlib.org/

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -21,8 +21,11 @@ build:
 requirements:
   build:
     - {{ compiler('cxx') }}
+    - autoconf  # [unix]
+    - automake  # [unix]
     - cmake
-    - ninja-base
+    - make  # [unix]
+    - ninja-base  # [win]
   host:
     - boost-cpp 1.73.0
   run:


### PR DESCRIPTION
 - Need to use autotools and make to build quantlib-config, required to build quantlib-python.
 - build number set to 1.