### PR TITLE
quantlib 1.41

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -40,6 +40,9 @@ test:
     - quantlib-test-suite --log_level=message  # [win]
     # quantlib-config is built only for unix-like systems
     - quantlib-config --version  # [not win]
+    - quantlib-config --libs  # [not win]
+    - test -f $PREFIX/lib/libQuantLib${SHLIB_EXT}  # [unix]
+    - test -f $PREFIX/include/ql/quantlib.hpp  # [unix]
 
 about:
   home: https://www.quantlib.org/

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,7 +1,6 @@
-# this package is not intended to go on the default channel
 {% set name = "QuantLib" %}
-{% set version = "1.29" %}
-{% set sha256 = "b8127fb6fe5562dfabfcb7d62df4ba2f018de39d7fbe7df2b7a688578516b4b7" %}
+{% set version = "1.41" %}
+{% set sha256 = "c5e9a30fce129660932e643647eb9a14e19ec24344d6b813c57c054187b03bdd" %}
 
 package:
   name: {{ name|lower }}
@@ -9,11 +8,16 @@ package:
 
 source:
   fn: {{ name }}-{{ version }}.tar.gz
-  url: https://github.com/lballabio/QuantLib/releases/download/{{ name }}-v{{ version }}/{{ name }}-{{ version }}.tar.gz
+  url: https://github.com/lballabio/QuantLib/releases/download/v{{ version }}/{{ name }}-{{ version }}.tar.gz
   sha256: {{ sha256 }}
+  patches:
+    # test-suite build defines BOOST_ALL_DYN_LINK when Boost_USE_STATIC_LIBS=OFF,
+    # which forces auto-linking against versioned boost shared libs that don't
+    # exist under that name in libboost-devel. We only need the header-only parts.
+    - patches/0001-Remove-use-of-BOOST_ALL_DYN_LINK.patch  # [win]
 
 build:
-  number: 1
+  number: 0
   skip: true  # [win and vc<14]
   run_exports:
     - {{ pin_subpackage('quantlib', max_pin='x') }}  # [not win]
@@ -27,9 +31,9 @@ requirements:
     - make  # [unix]
     - ninja-base  # [win]
   host:
-    - boost-cpp 1.73.0
-  run:
-    - boost-cpp >=1.73.0,<2.0a0
+    # libboost-devel has run_exports that auto-pin libboost on the downstream,
+    # so we don't need to list libboost in `run:` explicitly.
+    - libboost-devel
 
 test:
   commands:

--- a/recipe/patches/0001-Remove-use-of-BOOST_ALL_DYN_LINK.patch
+++ b/recipe/patches/0001-Remove-use-of-BOOST_ALL_DYN_LINK.patch
@@ -1,0 +1,26 @@
+From 0ae47e6a29f98fa7bd84f006dfc005c9009df788 Mon Sep 17 00:00:00 2001
+From: Isuru Fernando <ifernando@quansight.com>
+Date: Mon, 28 Oct 2024 15:11:35 -0500
+Subject: [PATCH] Remove use of BOOST_ALL_DYN_LINK
+
+Since we are using header only parts using BOOST_ALL_NO_LIB
+---
+ test-suite/CMakeLists.txt | 3 ---
+ 1 file changed, 3 deletions(-)
+
+diff --git a/test-suite/CMakeLists.txt b/test-suite/CMakeLists.txt
+index 0a3ca24..90c33ad 100644
+--- a/test-suite/CMakeLists.txt
++++ b/test-suite/CMakeLists.txt
+@@ -189,9 +189,6 @@ set(QL_TEST_HEADERS
+
+ if (QL_BUILD_TEST_SUITE)
+     add_library(ql_test OBJECT ${QL_TEST_SOURCES} ${QL_TEST_HEADERS})
+-    if (NOT Boost_USE_STATIC_LIBS)
+-        target_compile_definitions(ql_test PUBLIC BOOST_ALL_DYN_LINK)
+-    endif()
+     if(MSVC AND CMAKE_UNITY_BUILD)
+         # for Unity builds, we need to add /bigobj
+         target_compile_options(ql_test PUBLIC "/bigobj")
+--
+2.51.0


### PR DESCRIPTION
quantlib 1.41

**Destination channel:** defaults

### Links

- [PKG-12658](https://anaconda.atlassian.net/browse/PKG-12658)
- [Upstream repository](https://github.com/lballabio/QuantLib)
- [Upstream changelog](https://github.com/lballabio/QuantLib/releases/tag/v1.41)
- Relevant dependency PRs:

### Explanation of changes:

- **Promote to defaults.** Previously the recipe header said "not intended to go on the default channel" and the feedstock shipped to the `services` channel only. Customer (MUFG) has requested quantlib in pkgs/main; removing the comment and letting the build target defaults.
- **Bump 1.29 → 1.41.**

[PKG-12658]: https://anaconda.atlassian.net/browse/PKG-12658?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ